### PR TITLE
Restructure command handling

### DIFF
--- a/src/util/manager/database.ts
+++ b/src/util/manager/database.ts
@@ -67,7 +67,7 @@ export default class DatabaseManager extends Manager {
     };
     setup().then(() => {
       this.bot.logger.info(
-        "Cached cirlce, response, and reaction role data..."
+        "Cached circle, response, and reaction role data..."
       );
     });
   }
@@ -78,7 +78,7 @@ export default class DatabaseManager extends Manager {
       useFindAndModify: false,
     });
     this.m.connection.on("error", (err) => {
-      this.bot.logger.error("Databse connection error...");
+      this.bot.logger.error("Database connection error...");
       this.bot.logger.error(err);
     });
   }


### PR DESCRIPTION
Reordered checks and moved argument parsing to the end, so that less
errors are falsely reported. This change does not present any fix for
the mismatched quotes problem, just makes it occur less often.

Added comments and refactored the code to make it more readable.

Edited some responses to make them more descriptive or succinct as
needed, or to fix nickb's spelling mistakes.