### PR TITLE
Add mentor points features

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "tsc",
     "boot": "node dist/index.js",
     "start": "npm run build && npm run boot",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "clean": "tsc --build --clean"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/jafrilli/acm-bot#readme",
   "dependencies": {
     "@google-cloud/firestore": "^4.13.0",
+    "axios": "^0.21.4",
     "body-parser": "^1.19.0",
     "discord.js": "^12.5.3",
     "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "homepage": "https://github.com/jafrilli/acm-bot#readme",
   "dependencies": {
     "@google-cloud/firestore": "^4.13.0",
+    "body-parser": "^1.19.0",
     "discord.js": "^12.5.3",
+    "express": "^4.17.1",
     "is-url": "^1.2.4",
     "leeks.js": "^0.0.8",
     "mongoose": "^5.12.13",

--- a/src/api/bot.ts
+++ b/src/api/bot.ts
@@ -10,6 +10,7 @@ import ScheduleManager from "../util/manager/schedule";
 import CircleManager from "../util/manager/circle";
 import FirestoreManager from "../util/manager/firestore";
 import ResolveManager from "../util/manager/resolve";
+import ExpressManager from "../util/manager/express";
 import PointsManager from "../util/manager/points";
 import ActivityManager from "../util/manager/activity";
 import VerificationManager from "../util/manager/verification";
@@ -35,6 +36,7 @@ export interface ManagerList {
   circle: CircleManager;
   firestore: FirestoreManager;
   resolve: ResolveManager;
+  express: ExpressManager;
   points: PointsManager;
   activity: ActivityManager;
 }
@@ -66,6 +68,7 @@ export default class Bot extends Client {
       circle: new CircleManager(this),
       firestore: new FirestoreManager(this),
       resolve: new ResolveManager(this),
+      express: new ExpressManager(this),
       points: new PointsManager(this),
       activity: new ActivityManager(this),
     };

--- a/src/api/command.ts
+++ b/src/api/command.ts
@@ -50,7 +50,8 @@ export default abstract class Command {
     this.userPermissions = config.userPermissions || 0;
     this.requiredRoles = config.requiredRoles;
   }
-  public abstract exec(context: CommandContext): void;
+
+  public abstract exec(context: CommandContext): Promise<void>;
 
   public infoEmbed(): MessageEmbed {
     const embed = new MessageEmbed()
@@ -72,6 +73,7 @@ export default abstract class Command {
       .addField("Cooldown", `${this.cooldown} seconds`, true);
     return embed;
   }
+
   public sendInvalidUsage(msg: Message, bot: Bot): void {
     bot.response.emit(
       msg.channel,
@@ -79,6 +81,7 @@ export default abstract class Command {
       "invalid"
     );
   }
+
   public getUsageText(prefix: string): string {
     return this.usage.length > 0
       ? "Usage\n" + this.usage.map((e) => `${prefix}${e}`).join("\n")

--- a/src/api/manager.ts
+++ b/src/api/manager.ts
@@ -2,8 +2,13 @@ import Bot from "./bot";
 
 export default abstract class Manager {
   public bot: Bot;
+
   constructor(bot: Bot) {
     this.bot = bot;
   }
+
+  /**
+   * Initialize anything required for this manager to work.
+   */
   public abstract init(): void;
 }

--- a/src/command/circle.ts
+++ b/src/command/circle.ts
@@ -1,17 +1,12 @@
 import Command, { CommandContext } from "../api/command";
 import Bot from "../api/bot";
-import {
-  CategoryChannel,
-  Message,
-  OverwriteResolvable,
-  TextChannel,
-} from "discord.js";
+import { CategoryChannel, Message, OverwriteResolvable } from "discord.js";
 import Wizard, {
-  TextWizardNode,
-  UserMentionWizardNode,
+  ColorWizardNode,
   EmojiWizardNode,
   GraphicWizardNode,
-  ColorWizardNode,
+  TextWizardNode,
+  UserMentionWizardNode,
 } from "../util/wizard";
 import { settings } from "../settings";
 import { CircleData } from "../api/schema";
@@ -26,7 +21,7 @@ export default class CircleCommand extends Command {
     });
   }
 
-  public async exec({ msg, bot, args }: CommandContext): Promise<void> {
+  public async exec({ msg, bot, args }: CommandContext) {
     switch (args[0]) {
       case "add":
         await addCircle(bot, msg, args);
@@ -42,6 +37,7 @@ export default class CircleCommand extends Command {
     }
   }
 }
+
 async function addCircle(bot: Bot, msg: Message, args: string[]) {
   const wizard = new Wizard(msg, undefined, {
     title: "__**Circle Creation**__ ",

--- a/src/command/ping.ts
+++ b/src/command/ping.ts
@@ -1,5 +1,5 @@
-import { Message } from "discord.js";
 import Command, { CommandContext } from "../api/command";
+
 export default class PingCommand extends Command {
   constructor() {
     super({
@@ -7,7 +7,8 @@ export default class PingCommand extends Command {
       description: "Fetch the bot's response time...",
     });
   }
-  public exec({ msg, bot, args }: CommandContext): void {
+
+  public async exec({ msg, bot, args }: CommandContext) {
     const startTime = new Date().getTime();
     msg.channel
       .send("Ping: This message should be deleted...")

--- a/src/command/points.ts
+++ b/src/command/points.ts
@@ -1,0 +1,532 @@
+import { settings } from "../settings";
+import {
+  Message,
+  MessageAttachment,
+  MessageEmbed,
+  User,
+  VoiceChannel,
+} from "discord.js";
+import Command, { CommandContext } from "../api/command";
+import Bot from "../api/bot";
+import axios from "axios";
+
+export default class PointsCommand extends Command {
+  constructor() {
+    super({
+      name: "points",
+      description: "Suite of commands to manage the points system",
+      longDescription:
+        "Suite of commands to manage the points system.\n" +
+        "You can check and award points, display the leaderboard, or hold a weighted raffle.\n" +
+        "Most options also have an alias for ease of use:\n" +
+        "`check`: `c`\n" +
+        "`award`: `a`\n" +
+        "`leaderboard`: `lb`\n" +
+        "`raffle`: `r`",
+      usage: [
+        "points check [user]",
+        "points award <amount> <activity-id> [user1 [user2 [user3 ...]]]",
+        "points leaderboard <mentee|mentor|both> [limit=0 (all)]",
+        "points raffle [winners=1]",
+        "points vcevent <amount> <activity-id> <threshold-minutes>",
+        "points vcsnapshot <amount> <activity-id>",
+      ],
+      dmWorks: false,
+      requiredRoles: [settings.points.staffRole],
+    });
+  }
+
+  public async exec({ msg, bot, args }: CommandContext) {
+    if (!msg.guild) {
+      // shouldn't ever happen, but we"re gonna include it just for typescript 😄
+      await msg.reply("This command cannot be run in DMs!");
+      return;
+    }
+
+    if (args.length < 1) return this.sendInvalidUsage(msg, bot);
+
+    switch (args[0].toLowerCase()) {
+      case "check":
+      case "c": {
+        // default to the author if arg not included
+        let user: User | undefined | null = msg.author;
+
+        if (args.length > 1) {
+          const unresolvedUser = args[1];
+          user = undefined;
+
+          if (/.+@.+\..+/.test(unresolvedUser)) {
+            // email resolve
+            const users = await bot.managers.points.emailsToSnowflakes(
+              new Set([unresolvedUser])
+            );
+            if (users.length == 1) {
+              // email find, now resolve by userID
+              user = await bot.users.resolve(users[0]);
+            }
+          } else {
+            // discord resolve (nickname, username, id, etc)
+            const member = await bot.managers.resolve.resolveGuildMember(
+              unresolvedUser,
+              msg.guild
+            );
+            user = member?.user;
+          }
+
+          if (!user) {
+            await bot.response.emit(
+              msg.channel,
+              `I couldn't anyone named \`${unresolvedUser}\`.`,
+              "invalid"
+            );
+            return;
+          }
+        }
+
+        const data = await bot.managers.points.getUser(user.id);
+        if (data != undefined) {
+          // we build a nice embed scorecard
+          let scorecardEmbed = new MessageEmbed({
+            color: "#93c2db",
+            author: {
+              name: `${user.tag} (${data.full_name})`,
+              iconURL: user.avatarURL() ?? "",
+            },
+            title: `${data?.points} points`,
+            description: "\n",
+            footer: {
+              text: "ACM Education",
+              iconURL: "https://i.imgur.com/THllTFL.png",
+            },
+          });
+
+          // add score breakdown if it exists
+          let userActivities = [];
+          if (data?.activities) {
+            for (let activity in data?.activities) {
+              userActivities.push(
+                `**${activity}**: ${data?.activities[activity]}`
+              );
+            }
+            // now we sort userActivities, case-insensitive
+            userActivities.sort((a, b) => {
+              return a.toLowerCase().localeCompare(b.toLowerCase());
+            });
+            // finally, add to description
+            scorecardEmbed.description =
+              "__**Activities**__\n" + userActivities.join("\n");
+          }
+
+          await msg.channel.send(scorecardEmbed);
+          return;
+        } else {
+          await bot.response.emit(
+            msg.channel,
+            `${user} doesn't seem to be registered in the system.`,
+            "invalid"
+          );
+          return;
+        }
+      }
+
+      case "award":
+      case "a": {
+        if (args.length < 3) {
+          await bot.response.emit(
+            msg.channel,
+            `Award some points to user(s) for completing some activity.\n` +
+              `Specify the users by pinging them or attaching a zoom attendance sheet.\n` +
+              `Usage: \`${bot.settings.prefix}${this.usage[1]}\`\n`,
+            "invalid"
+          );
+          return;
+        }
+
+        const unresolvedPoints = args[1];
+        const activityId = args[2];
+        const awardees = new Set<string>();
+
+        const points = +unresolvedPoints;
+
+        // invalid award amount
+        if (isNaN(points)) {
+          await bot.response.emit(
+            msg.channel,
+            `\`${unresolvedPoints}\` is not a valid number.`,
+            "invalid"
+          );
+          return;
+        }
+
+        // scan message for userIds. This will catch mentions but not usernames/tags
+        msg.content.match(/[\d]{17,18}/g)?.forEach((userId) => {
+          awardees.add(userId);
+        });
+
+        // also scan message for usernames
+        for (const arg of args) {
+          const user = await bot.managers.resolve.resolveGuildMember(
+            arg,
+            msg.guild!,
+            new Set<string>(["tag"]),
+            false
+          );
+          if (user) awardees.add(user.id);
+        }
+
+        // process awardees inn the attachment
+        let attachmentAwardees = await processAttachments(bot, msg);
+        if (attachmentAwardees) {
+          for (let id of attachmentAwardees) {
+            awardees.add(id);
+          }
+        }
+
+        const { success, failure } = await bot.managers.points.awardPoints(
+          points,
+          activityId,
+          awardees
+        );
+
+        // send back our results with mentions but not pings
+        await msg.reply(
+          `Awarded **${points}** points to **${
+            success.length
+          }** users for completing **${activityId}**:\n${success.join(" ")}\n` +
+            (failure.length
+              ? `${failure.length} users were not registered: ${failure.join(
+                  " "
+                )}`
+              : ""),
+          { allowedMentions: { users: [] } }
+        );
+        return;
+      }
+
+      case "leaderboard":
+      case "lb": {
+        if (
+          args.length < 2 ||
+          (args[1] != "mentee" && args[1] != "mentor" && args[1] != "both")
+        ) {
+          await bot.response.emit(
+            msg.channel,
+            `Usage: \`${bot.settings.prefix}${this.usage[2]}\`\n`,
+            "invalid"
+          );
+          return;
+        }
+
+        const filter = args[1];
+        const unresolvedNumUsers = args[2];
+        let numUsers = 0; // default to all
+
+        if (unresolvedNumUsers) {
+          numUsers = +unresolvedNumUsers;
+
+          // invalid number of users
+          if (isNaN(numUsers)) {
+            await bot.response.emit(
+              msg.channel,
+              `\`${numUsers}\` is not a valid number.`,
+              "invalid"
+            );
+            return;
+          }
+        }
+
+        const allPairs = await bot.managers.points.getLeaderboard(
+          filter,
+          numUsers
+        );
+
+        let descriptionArr: string[] = [];
+        allPairs.forEach((pair, i) => {
+          if (pair.points > 0)
+            descriptionArr.push(
+              `\`${i + 1}\`. <@${pair.users.join(">+<@")}>: ${
+                pair.points
+              } points`
+            );
+        });
+
+        await msg.channel.send(
+          new MessageEmbed({
+            title: "Leaderboard",
+            description: descriptionArr.join("\n"),
+          })
+        );
+        return;
+      }
+
+      case "raffle":
+      case "r": {
+        const allPairs = await bot.managers.points.getLeaderboard("both");
+        const unresolvedNumWinners = args[1];
+        let sum = 0;
+        let numWinners: number;
+        let winningNumbers = new Set<number>();
+        let winningUsers: string[] = [];
+        let processedTickets = 0;
+
+        if (unresolvedNumWinners) {
+          numWinners = +unresolvedNumWinners;
+
+          // invalid number of winners
+          if (isNaN(numWinners) || numWinners < 1 || numWinners > 50) {
+            await bot.response.emit(
+              msg.channel,
+              `\`${unresolvedNumWinners}\` is not a valid number of winners between 1 and 50 (inclusive).`,
+              "invalid"
+            );
+            return;
+          }
+        } else {
+          // default to 1 winner
+          numWinners = 1;
+        }
+
+        // first, we want to find the sum of all points for pairs with > 0 points
+        const filteredPairs = allPairs.filter((pair) => pair.points > 0);
+        filteredPairs.forEach((pair) => {
+          sum += pair.points;
+        });
+
+        // now we want to generate random numbers accordingly
+        for (let i = 0; i < numWinners; i++) {
+          winningNumbers.add(Math.random() * sum);
+        }
+
+        // pick out winners
+        for (let pair of filteredPairs) {
+          let winnerCount = 0;
+          processedTickets += pair.points;
+          // count up all the winning tickets
+          winningNumbers.forEach((ticket) => {
+            if (ticket < processedTickets) {
+              winnerCount++;
+              winningNumbers.delete(ticket);
+            }
+          });
+
+          // add the winning count to the person's stats
+          if (winnerCount > 0)
+            winningUsers.push(`<@${pair.users.join(">+<@")}>: ${winnerCount}`);
+
+          // stop processing once all the winning numbers are gone
+          if (winningNumbers.size == 0) break;
+        }
+
+        await msg.channel.send(
+          new MessageEmbed({
+            title: "🎉 The winners (and how many times they won)",
+            description: winningUsers.join("\n"),
+          })
+        );
+        return;
+      }
+      case "vcevent":
+        if (args.length < 4) {
+          return bot.response.emit(
+            msg.channel,
+            `Stop a vc event and award points to users who stay for some duration.\n` +
+              `Usage: \`${bot.settings.prefix}${this.usage[4]}\`\n`,
+            "invalid"
+          );
+        }
+
+        const unresolvedPoints = args[1];
+        const unresolvedThreshold = args[3];
+        const activityId = args[2];
+        let attendees = new Set<string>();
+        let voiceChannel: VoiceChannel | null | undefined;
+        const points = +unresolvedPoints;
+        const threshold = +unresolvedThreshold;
+
+        // invalid award amount
+        if (isNaN(points)) {
+          await bot.response.emit(
+            msg.channel,
+            `\`${unresolvedPoints}\` is not a valid number.`,
+            "invalid"
+          );
+          return;
+        }
+        // invalid threshold amount
+        if (isNaN(threshold)) {
+          await bot.response.emit(
+            msg.channel,
+            `\`${unresolvedThreshold}\` is not a valid number.`,
+            "invalid"
+          );
+          return;
+        }
+        // attempt to resolve the vc
+        voiceChannel = msg.member?.voice.channel;
+        if (!voiceChannel) {
+          await bot.response.emit(
+            msg.channel,
+            `Please join a voice channel!`,
+            "invalid"
+          );
+          return;
+        }
+        const data = bot.managers.activity.stopVoiceEvent(voiceChannel);
+        if (!data) {
+          await bot.response.emit(
+            msg.channel,
+            `No VC Event is running in ${voiceChannel}`,
+            "error"
+          );
+          return;
+        } else {
+          let sorted = Array.from(data.keys()).sort(
+            (a, b) => data.get(b)! - data.get(a)!
+          );
+          let descriptionArr: string[] = [];
+
+          sorted.forEach((userID, i) => {
+            const time = Math.round(data.get(userID)! / 60000);
+            descriptionArr.push(
+              `\`${i + 1}\`. <@${userID}>: ${time} minute${
+                time == 1 ? "" : "s"
+              }`
+            );
+            if (time >= threshold) attendees.add(userID);
+          });
+
+          const { success, failure } = await bot.managers.points.awardPoints(
+            points,
+            activityId,
+            attendees
+          );
+
+          await msg.channel.send(
+            new MessageEmbed({
+              title: "Time spent in VC",
+              description: descriptionArr.join("\n"),
+            })
+          );
+
+          await msg.reply(
+            `Awarded **${points}** points to **${
+              success.length
+            }** users for completing **${activityId}**:\n${success.join(
+              " "
+            )}\n` +
+              (failure.length
+                ? `${failure.length} users were not registered: ${failure.join(
+                    " "
+                  )}`
+                : ""),
+            { allowedMentions: { users: [] } }
+          );
+          return;
+        }
+
+      case "vcsnapshot": {
+        if (args.length < 3) {
+          await bot.response.emit(
+            msg.channel,
+            `Award some points to user(s) in your current voice channel.\n` +
+              `Usage: \`${bot.settings.prefix}${this.usage[5]}\`\n`,
+            "invalid"
+          );
+          return;
+        }
+
+        const unresolvedPoints = args[1];
+        const activityId = args[2];
+        let attendees = new Set<string>();
+        let voiceChannel: VoiceChannel | null | undefined;
+        const points = +unresolvedPoints;
+
+        // invalid award amount
+        if (isNaN(points)) {
+          await bot.response.emit(
+            msg.channel,
+            `\`${unresolvedPoints}\` is not a valid number.`,
+            "invalid"
+          );
+          return;
+        }
+
+        // attempt to resolve the vc
+        voiceChannel = msg.member?.voice.channel;
+        if (!voiceChannel) {
+          await bot.response.emit(
+            msg.channel,
+            `Please join a voice channel!`,
+            "invalid"
+          );
+          return;
+        }
+
+        for (const [, member] of voiceChannel.members) {
+          if (member.user.bot) continue;
+          attendees.add(member.id);
+        }
+
+        const { success, failure } = await bot.managers.points.awardPoints(
+          points,
+          activityId,
+          attendees
+        );
+
+        await msg.reply(
+          `Awarded **${points}** points to **${
+            success.length
+          }** users for completing **${activityId}**:\n${success.join(" ")}\n` +
+            (failure.length
+              ? `${failure.length} users were not registered: ${failure.join(
+                  " "
+                )}`
+              : ""),
+          { allowedMentions: { users: [] } }
+        );
+        return;
+      }
+
+      default:
+        await this.sendInvalidUsage(msg, bot);
+        return;
+    }
+  }
+}
+
+async function processAttachments(client: Bot, msg: Message) {
+  let awardees = new Set<string>();
+  if (msg.attachments.size == 0) return;
+  await Promise.all(
+    msg.attachments.map(async (val) => {
+      let attachmentAwardees = await processCSV(client, val);
+      attachmentAwardees?.forEach((id) => {
+        awardees.add(id);
+      });
+    })
+  );
+  return awardees;
+}
+
+async function processCSV(bot: Bot, attachment: MessageAttachment) {
+  let csvRaw: string;
+  const emails: Set<string> = new Set<string>();
+
+  try {
+    csvRaw = (await axios.get(attachment.url)).data;
+    const csvLines = csvRaw.split("\n");
+    // determine email column
+    const headers = csvLines[0].split(",");
+    const emailColNum = headers.indexOf("Email");
+
+    // extract emails from remaining csv
+    for (let lineNum = 1; lineNum < csvLines.length; lineNum++) {
+      let email = csvLines[lineNum].split(",")[emailColNum];
+      emails.add(email);
+    }
+  } catch (error) {
+    return;
+  }
+
+  return await bot.managers.points.emailsToSnowflakes(emails);
+}

--- a/src/command/remind.ts
+++ b/src/command/remind.ts
@@ -1,5 +1,4 @@
 import Command, { CommandContext } from "../api/command";
-import schedule, { Job } from "node-schedule";
 
 export default class RemindCommand extends Command {
   constructor() {
@@ -10,7 +9,7 @@ export default class RemindCommand extends Command {
     });
   }
 
-  public exec({ msg, bot, args }: CommandContext): void {
+  public async exec({ msg, bot, args }: CommandContext) {
     if (args.length < 2) return this.sendInvalidUsage(msg, bot);
 
     const minutes = parseInt(args[0]);

--- a/src/command/shoutout.ts
+++ b/src/command/shoutout.ts
@@ -1,8 +1,6 @@
-import Command from "../api/command";
-import { CommandContext } from "../api/command";
+import Command, { CommandContext } from "../api/command";
 import { settings } from "../settings";
 import { MessageEmbed, TextChannel } from "discord.js";
-import color from "../util/checker";
 
 export default class ShoutoutCommand extends Command {
   constructor() {
@@ -12,7 +10,8 @@ export default class ShoutoutCommand extends Command {
       usage: ["shoutout [list of mentions] [reason for shoutout]"],
     });
   }
-  public exec({ msg, bot, args }: CommandContext): void {
+
+  public async exec({ msg, bot, args }: CommandContext) {
     if (!/^<@!?[\d]{17,18}>/.test(args[0]))
       return bot.response.emit(msg.channel, "No user mentions...", "invalid");
 

--- a/src/endpoint/mentorpoints.ts
+++ b/src/endpoint/mentorpoints.ts
@@ -1,0 +1,34 @@
+import { Express, Request, Response } from "express";
+import Bot from "../api/bot";
+
+/* Endpoints that handle external functionality related to the points system */
+
+module.exports = (app: Express, bot: Bot) => {
+  // Activities form endpoint for typeform
+  app.post("/points-form", async (req: Request, res: Response) => {
+    res.status(200).end();
+    await bot.managers.points.handlePointsTypeform(req.body).catch((e) => {
+      bot.logger.error(`Call to /points-form was unable to be handled: ${e}`);
+    });
+  });
+
+  // Registration form endpoint for typeform to hit
+  app.post("/registration-form", async (req: Request, res: Response) => {
+    res.status(200).end();
+    await bot.managers.points
+      .handleRegistrationTypeform(req.body)
+      .catch((e) => {
+        bot.logger.error(
+          `Call to /registration-form was unable to be handled: ${e}`
+        );
+      });
+  });
+
+  // any point end point for typeform to hit. It just needs to arrive with a score and the email as q1.
+  app.post("/generic-form", async (req: Request, res: Response) => {
+    res.status(200).end();
+    await bot.managers.points.handleGenericTypeform(req.body).catch((e) => {
+      bot.logger.error(`Call to /generic-form was unable to be handled: ${e}`);
+    });
+  });
+};

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,8 +14,6 @@ export interface Settings {
   };
   express: {
     port: number;
-    privateKey: string;
-    cert: string;
   };
   keys: {
     sheets: string;

--- a/src/util/manager/event.ts
+++ b/src/util/manager/event.ts
@@ -1,6 +1,4 @@
-import { Collection } from "discord.js";
 import Manager from "../../api/manager";
-import Command from "../../api/command";
 import Bot from "../../api/bot";
 import * as fs from "fs";
 
@@ -13,10 +11,14 @@ export default class EventManager extends Manager {
     super(bot);
     this.path = path;
   }
+
   public init(): void {
     fs.readdir(this.path, (err, files) => {
       this.bot.logger.info(`Found ${files.length} event(s)...`);
       files.forEach((file) => {
+        // Skip non-js files, such as map files.
+        if (!file.endsWith(".js")) return;
+
         const e = require(`${
           this.path.endsWith("/") ? this.path : this.path + "/"
         }${file}`);

--- a/src/util/manager/express.ts
+++ b/src/util/manager/express.ts
@@ -1,0 +1,58 @@
+import fs from "fs";
+import bodyParser from "body-parser";
+import express, { Express, Request, Response } from "express";
+import http from "http";
+import Bot from "../../api/bot";
+import { settings } from "../../settings";
+import Manager from "../../api/manager";
+
+export default class ExpressManager extends Manager {
+  public app: Express;
+  public port: number;
+
+  public endpointPath: string;
+  public server: http.Server | null = null;
+
+  constructor(bot: Bot) {
+    super(bot);
+    this.app = express();
+
+    this.port = settings.express.port;
+    this.endpointPath = __dirname + "/../../endpoint/";
+  }
+
+  /**
+   * Setup express application and dynamically load endpoints
+   */
+  async init() {
+    this.app.use(bodyParser.urlencoded({ extended: true }));
+    this.app.use(bodyParser.json());
+    this.app.use(bodyParser.raw());
+
+    this.setupEndpoints();
+
+    this.app.listen(this.port, () => {
+      this.bot.logger.info(`Express server started on port ${this.port}!`);
+    });
+  }
+
+  setupEndpoints() {
+    if (!fs.existsSync(this.endpointPath)) {
+      this.bot.logger.error(
+        `No express endpoints found at ${this.endpointPath}!`
+      );
+      return;
+    }
+    const endpointFiles: string[] = fs.readdirSync(this.endpointPath);
+    endpointFiles.forEach((file) => {
+      // TODO: import logic from each file
+    });
+
+    // Log endpoint names
+    this.app._router.stack.forEach((r: any) => {
+      if (r.route && r.route.path) {
+        this.bot.logger.info(`Registered the '${r.route.path}' endpoint!`);
+      }
+    });
+  }
+}

--- a/src/util/manager/express.ts
+++ b/src/util/manager/express.ts
@@ -45,7 +45,10 @@ export default class ExpressManager extends Manager {
     }
     const endpointFiles: string[] = fs.readdirSync(this.endpointPath);
     endpointFiles.forEach((file) => {
-      // TODO: import logic from each file
+      // Skip non-js files, such as map files.
+      if (!file.endsWith(".js")) return;
+
+      require(this.endpointPath + file)(this.app, this.bot);
     });
 
     // Log endpoint names

--- a/src/util/manager/points.ts
+++ b/src/util/manager/points.ts
@@ -97,7 +97,7 @@ export default class PointsManager extends Manager {
   async handlePointsTypeform(typeformData: any) {
     const points: number = typeformData.form_response.calculated.score;
     const title: string = typeformData.form_response.definition.title;
-    const answers: any = typeformData.form_resopnse.answers;
+    const answers: any = typeformData.form_response.answers;
     const confirmationChannel = (await this.bot.channels.fetch(
       this.privateChannelId
     )) as TextChannel;
@@ -154,7 +154,7 @@ export default class PointsManager extends Manager {
       first_name: answers[4].text,
       last_name: answers[5].text,
       full_name: answers[4].text + " " + answers[5].text,
-      email: answers[6].email.toLowercase(),
+      email: answers[6].email.toLowerCase(),
       tag: answers[7].text,
     };
 
@@ -167,7 +167,7 @@ export default class PointsManager extends Manager {
         "success"
       );
       await this.bot.managers.firestore.firestore
-        ?.collection("points_system")
+        ?.collection("points_system_f21")
         .doc("pairs")
         .set(
           {
@@ -206,12 +206,12 @@ export default class PointsManager extends Manager {
     data.tag = member.user.tag;
 
     await this.bot.managers.firestore.firestore
-      ?.collection("points_system/users/profiles")
+      ?.collection("points_system_f21/users/profiles")
       .doc(data.snowflake)
       .set(data, { merge: true });
 
     await this.bot.managers.firestore.firestore
-      ?.collection("points_system")
+      ?.collection("points_system_f21")
       .doc("email_to_discord")
       .set({ [data.email]: data.snowflake }, { merge: true });
     if (notify)
@@ -330,7 +330,7 @@ export default class PointsManager extends Manager {
 
     for (const snowflake of awardees.values()) {
       const docRef = this.bot.managers.firestore.firestore
-        ?.collection("points_system/users/profiles")
+        ?.collection("points_system_f21/users/profiles")
         .doc(snowflake);
       const doc = await docRef?.get();
 
@@ -374,7 +374,7 @@ export default class PointsManager extends Manager {
     let exists: boolean | undefined;
     let data: UserPointsData | undefined;
     await this.bot.managers.firestore.firestore
-      ?.collection("points_system/users/profiles")
+      ?.collection("points_system_f21/users/profiles")
       .doc(snowflake)
       .get()
       .then(async (doc) => {
@@ -387,7 +387,7 @@ export default class PointsManager extends Manager {
   async emailsToSnowflakes(emails: Set<string>): Promise<string[]> {
     const snowflakes: string[] = [];
     await this.bot.managers.firestore.firestore
-      ?.collection("points_system")
+      ?.collection("points_system_f21")
       .doc("email_to_discord")
       .get()
       .then(async (doc) => {
@@ -413,14 +413,14 @@ export default class PointsManager extends Manager {
       UserPointsData
     >();
     const snapshot = await this.bot.managers.firestore.firestore
-      ?.collection("points_system/users/profiles")
+      ?.collection("points_system_f21/users/profiles")
       .get();
     snapshot?.forEach((doc) => {
       individualData.set(doc.id, doc.data() as UserPointsData);
     });
     const pairs = await (
       await this.bot.managers.firestore.firestore
-        ?.collection("points_system")
+        ?.collection("points_system_f21")
         .doc("pairs")
         .get()!
     ).data();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "skipLibCheck": true,
     "strict": false,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "sourceMap": true
   }
 }


### PR DESCRIPTION
Basically brings back mentor points functionality back, this time under the top-level path `points_system_f21/` in firestore. 

This (unfortunately?) involves bringing back the express server. 

Some minor changes that go along with this, in order of importance:
- Add debugger support by enabling source maps in tsconfig
- Only import `*.js` files in all dynamic loading (commands, endpoints, events). This used to be not too important, but is now required due to the source map files that are generated for debugging support. 
- Fix error reporting in CommandManager for commands that throw exceptions. Previously, the exceptions crashed the bot. 
- Changed return type of `Command::exec` to `Promise<void>` to require async
- Removed some unnecessary express configs from settings
- Fixed some more of nick's typos in the PointsManager. 
