### PR TITLE
Decrease chance of fatal failures

### DIFF
--- a/src/api/command.ts
+++ b/src/api/command.ts
@@ -38,7 +38,7 @@ export default abstract class Command {
   public userPermissions: bigint;
   public requiredRoles: string[] | undefined;
 
-  constructor(config: CommandConfig) {
+  protected constructor(config: CommandConfig) {
     this.name = config.name;
     this.description = config.description;
     this.longDescription = config.longDescription || config.description;

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -4,7 +4,7 @@ export default abstract class Event {
   public bot: Bot;
   public name: string;
 
-  constructor(bot: Bot, event: string) {
+  protected constructor(bot: Bot, event: string) {
     this.bot = bot;
     this.name = event;
   }

--- a/src/api/manager.ts
+++ b/src/api/manager.ts
@@ -3,7 +3,7 @@ import Bot from "./bot";
 export default abstract class Manager {
   public bot: Bot;
 
-  constructor(bot: Bot) {
+  protected constructor(bot: Bot) {
     this.bot = bot;
   }
 

--- a/src/command/circle.ts
+++ b/src/command/circle.ts
@@ -93,7 +93,7 @@ async function addCircle(bot: Bot, msg: Message, args: string[]) {
     mentionable: true,
     color: res[3],
   });
-  owner.roles.add(circleRole);
+  await owner.roles.add(circleRole);
   const permissions: OverwriteResolvable[] = [
     {
       id: msg.guild!.id,
@@ -129,8 +129,8 @@ async function addCircle(bot: Bot, msg: Message, args: string[]) {
       `Could not add circle to the database...`,
       "error"
     );
-    circleRole.delete();
-    circleChannel.delete();
+    await circleRole.delete();
+    await circleChannel.delete();
     return;
   }
 

--- a/src/command/points.ts
+++ b/src/command/points.ts
@@ -177,7 +177,7 @@ export default class PointsCommand extends Command {
 
         // process awardees inn the attachment
         let attachmentAwardees = await processAttachments(bot, msg);
-        for (const id of attachmentAwardees) {
+        for (const id of attachmentAwardees.values()) {
           awardees.add(id);
         }
 
@@ -506,9 +506,12 @@ export default class PointsCommand extends Command {
   }
 }
 
-async function processAttachments(client: Bot, msg: Message) {
+async function processAttachments(
+  client: Bot,
+  msg: Message
+): Promise<Set<string>> {
   let awardees = new Set<string>();
-  if (msg.attachments.size == 0) return;
+  if (msg.attachments.size == 0) return new Set<string>();
   await Promise.all(
     msg.attachments.map(async (val) => {
       let attachmentAwardees = await processCSV(client, val);

--- a/src/command/remind.ts
+++ b/src/command/remind.ts
@@ -37,7 +37,7 @@ export default class RemindCommand extends Command {
 
     const dateStr = date.toLocaleString("en-US", options);
 
-    bot.managers.scheduler.createTask({
+    await bot.managers.scheduler.createTask({
       cron: date,
       type: "reminder",
       payload: {

--- a/src/command/shoutout.ts
+++ b/src/command/shoutout.ts
@@ -51,8 +51,8 @@ export default class ShoutoutCommand extends Command {
     const channel = msg.guild?.channels.resolve(
       settings.channels.shoutout
     ) as TextChannel;
-    channel.send({ embeds: [embed] });
-    channel.send(
+    await channel.send({ embeds: [embed] });
+    await channel.send(
       msg.content.match(reg)![0].replace(settings.prefix + "shoutout", "")
     );
 

--- a/src/command/vcevent.ts
+++ b/src/command/vcevent.ts
@@ -69,7 +69,7 @@ export default class VCEventCommand extends Command {
             `No running VC Event in ${vc}...`,
             "error"
           );
-        this.printStats(msg.channel, vc, data);
+        await this.printStats(msg.channel, vc, data);
         break;
       case "stats":
         data = bot.managers.activity.voiceEventStats(vc);
@@ -79,7 +79,7 @@ export default class VCEventCommand extends Command {
             `No running VC Event in ${vc}...`,
             "error"
           );
-        this.printStats(msg.channel, vc, data);
+        await this.printStats(msg.channel, vc, data);
         break;
       case "list":
         const channels = Array.from(bot.managers.activity.voiceLog.keys()).map(

--- a/src/event/messagecreate.ts
+++ b/src/event/messagecreate.ts
@@ -7,8 +7,8 @@ export default class MessageCreateEvent extends Event {
     super(bot, "messageCreate");
   }
 
-  public emit(bot: Bot, msg: Message): void {
-    bot.managers.command.handle(msg);
-    bot.managers.verification.handle(msg);
+  public async emit(bot: Bot, msg: Message): Promise<void> {
+    await bot.managers.command.handle(msg);
+    await bot.managers.verification.handle(msg);
   }
 }

--- a/src/event/messagereactionadd.ts
+++ b/src/event/messagereactionadd.ts
@@ -8,7 +8,7 @@ export default class MessageReactionAddEvent extends Event {
   }
 
   public async emit(bot: Bot, reaction: MessageReaction, user: User) {
-    bot.managers.points.handleReactionAdd(reaction, user);
-    bot.managers.circle.handleReactionAdd(reaction, user);
+    await bot.managers.points.handleReactionAdd(reaction, user);
+    await bot.managers.circle.handleReactionAdd(reaction, user);
   }
 }

--- a/src/event/voicestateupdate.ts
+++ b/src/event/voicestateupdate.ts
@@ -8,6 +8,6 @@ export default class VoiceStateUpdateEvent extends Event {
   }
 
   public async emit(bot: Bot, oldMember: VoiceState, newMember: VoiceState) {
-    bot.managers.activity.handleVoiceStateUpdate(oldMember, newMember);
+    await bot.managers.activity.handleVoiceStateUpdate(oldMember, newMember);
   }
 }

--- a/src/util/checker.ts
+++ b/src/util/checker.ts
@@ -43,7 +43,7 @@ export default class CheckerUtils {
 
   public static isMediaURL(link: string) {
     if (!isUrl(link)) return false;
-    if (
+    return !(
       !link.toLowerCase().endsWith(".gif") &&
       !link.toLowerCase().endsWith(".jpg") &&
       !link.toLowerCase().endsWith(".png") &&
@@ -52,9 +52,6 @@ export default class CheckerUtils {
       !link.toLowerCase().endsWith(".jpg/") &&
       !link.toLowerCase().endsWith(".png/") &&
       !link.toLowerCase().endsWith(".jpeg/")
-    ) {
-      return false;
-    }
-    return true;
+    );
   }
 }

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -42,7 +42,7 @@ export default class LoggerUtil {
     const ampm = now.getHours() >= 12 ? "PM" : "AM";
     return `[${hours}:${minutes}:${seconds} ${ampm}]`;
   }
-  private strip(message: string) {
+  private static strip(message: string) {
     return message.replace(/\u001b\[.*?m/g, "");
   }
   private write(
@@ -80,7 +80,9 @@ export default class LoggerUtil {
       .join("\n");
     appendFileSync(
       `${this.logPath}${sep}acmbot.log`,
-      `${this.getDate()} ${this.strip(lvlText)} -> ${this.strip(msg)}\n`
+      `${this.getDate()} ${LoggerUtil.strip(lvlText)} -> ${LoggerUtil.strip(
+        msg
+      )}\n`
     );
 
     const output =

--- a/src/util/manager/activity.ts
+++ b/src/util/manager/activity.ts
@@ -1,9 +1,4 @@
-import {
-  Message,
-  StageChannel,
-  VoiceChannel,
-  VoiceState,
-} from "discord.js";
+import { Message, StageChannel, VoiceChannel, VoiceState } from "discord.js";
 import Bot from "../../api/bot";
 import Manager from "../../api/manager";
 import { settings } from "../../settings";
@@ -25,7 +20,7 @@ export default class ActivityManager extends Manager {
     this.activityLog = new Map<string, number>();
     this.voiceLog = new Map<string, Array<VoiceLogData>>();
   }
-  init() { }
+  init() {}
   async handleVoiceStateUpdate(oldMember: VoiceState, newMember: VoiceState) {
     const oldVC = oldMember.channel;
     const newVC = newMember.channel;
@@ -49,7 +44,7 @@ export default class ActivityManager extends Manager {
 
   startVoiceEvent(vc: VoiceChannel | StageChannel): boolean {
     if (this.voiceLog.has(vc.id)) return false;
-    const data = new Array();
+    const data = [];
     const now = Date.now();
     for (const id of vc.members.keys()) {
       data.push({
@@ -61,14 +56,18 @@ export default class ActivityManager extends Manager {
     this.voiceLog.set(vc.id, data);
     return true;
   }
-  stopVoiceEvent(vc: VoiceChannel | StageChannel): Map<string, number> | undefined {
+  stopVoiceEvent(
+    vc: VoiceChannel | StageChannel
+  ): Map<string, number> | undefined {
     if (!this.voiceLog.has(vc.id)) return undefined;
 
     const stats = this.voiceEventStats(vc);
     this.voiceLog.delete(vc.id);
     return stats;
   }
-  voiceEventStats(vc: VoiceChannel | StageChannel): Map<string, number> | undefined {
+  voiceEventStats(
+    vc: VoiceChannel | StageChannel
+  ): Map<string, number> | undefined {
     if (!this.voiceLog.has(vc.id)) return undefined;
     const data = [...this.voiceLog.get(vc.id)!];
     const now = Date.now();
@@ -89,7 +88,6 @@ export default class ActivityManager extends Manager {
         if (!stats.has(id)) stats.set(id, 0);
         stats.set(id, stats.get(id)! + (time - joinTime.get(id)!));
         joinTime.delete(id);
-        continue;
       } else {
         joinTime.set(id, time);
       }
@@ -108,8 +106,8 @@ export default class ActivityManager extends Manager {
     if (
       (indicators.hasKey("textActivity", msg.author.id) &&
         msg.createdTimestamp >
-        indicators.getValue("textActivity", msg.author.id)! +
-        cooldown * 1000) ||
+          indicators.getValue("textActivity", msg.author.id)! +
+            cooldown * 1000) ||
       !indicators.hasKey("textActivity", msg.author.id)
     ) {
       indicators.setKeyValue(
@@ -117,7 +115,7 @@ export default class ActivityManager extends Manager {
         msg.author.id,
         msg.createdTimestamp
       );
-      let { success, failure } = await this.bot.managers.points.awardPoints(
+      let { success } = await this.bot.managers.points.awardPoints(
         1,
         "Discord",
         new Set<string>([msg.author.id])
@@ -125,7 +123,8 @@ export default class ActivityManager extends Manager {
       if (success.length === 0) {
       } else {
         console.log(
-          `${new Date().toLocaleTimeString()}: ${msg.author.tag
+          `${new Date().toLocaleTimeString()}: ${
+            msg.author.tag
           } was awarded 1pt for activity (${msg.createdTimestamp})`
         );
       }

--- a/src/util/manager/circle.ts
+++ b/src/util/manager/circle.ts
@@ -10,7 +10,7 @@ import Bot from "../../api/bot";
 import Manager from "../../api/manager";
 
 export default class CircleManager extends Manager {
-  private circleChannelId: string;
+  private readonly circleChannelId: string;
 
   constructor(bot: Bot) {
     super(bot);
@@ -23,10 +23,10 @@ export default class CircleManager extends Manager {
     const channel = this.bot.channels.resolve(this.circleChannelId);
     const c = channel as TextChannel;
     await c.bulkDelete(50);
-    c.send(
+    await c.send(
       "https://cdn.discordapp.com/attachments/537776612238950410/826695146250567681/circles.png"
     );
-    c.send(
+    await c.send(
       `> :yellow_circle: Circles are interest groups made by the community!\n` +
         `> :door: Join one by reacting to the emoji attached to each.\n` +
         `> :crown: You can apply to make your own Circle by filling out this application: <https://apply.acmutd.co/circles>\n`
@@ -66,7 +66,7 @@ export default class CircleManager extends Manager {
         },
       });
       const msg = await c.send({ embeds: [embed] });
-      msg.react(`${circle.emoji}`);
+      await msg.react(`${circle.emoji}`);
     }
   }
 
@@ -102,7 +102,7 @@ export default class CircleManager extends Manager {
         { name: "**Members**", value: `${count ?? "N/A"}`, inline: true },
       ],
     });
-    message.edit({ embeds: [embed] });
+    await message.edit({ embeds: [embed] });
   }
 
   public async findMemberCount(id: string) {
@@ -126,7 +126,7 @@ export default class CircleManager extends Manager {
       if (reaction.emoji.name.includes(n)) reactionRes = obj.reactions[n];
     });
     if (!reactionRes) return;
-    reaction.users.remove(user.id);
+    await reaction.users.remove(user.id);
 
     const guild = await this.bot.guilds.fetch(settings.guild);
     const member = guild.members.resolve(user.id);
@@ -135,11 +135,11 @@ export default class CircleManager extends Manager {
       await member.roles.add(reactionRes);
 
       const chan = (await guild.channels.fetch(obj.channel)) as TextChannel;
-      chan.send(`${member}, welcome to ${obj.name}!`);
+      await chan.send(`${member}, welcome to ${obj.name}!`);
     } else {
       await member.roles.remove(reactionRes);
     }
-    this.update(reaction.message.channel as TextChannel, reactionRes);
+    await this.update(reaction.message.channel as TextChannel, reactionRes);
   }
 }
 

--- a/src/util/manager/command.ts
+++ b/src/util/manager/command.ts
@@ -126,8 +126,9 @@ export default class CommandManager extends Manager {
       this.bot.managers.indicator.addUser("usingCommand", msg.author);
       await cmd.exec({ bot: this.bot, msg, args });
     } catch (e) {
-      msg.reply("Command execution failed. Please contact a bot maintainer...");
-      throw e;
+      await msg.reply(
+        "Command execution failed. Please contact a bot maintainer..."
+      );
     } finally {
       this.bot.managers.indicator.removeUser("usingCommand", msg.author);
     }

--- a/src/util/manager/database.ts
+++ b/src/util/manager/database.ts
@@ -16,7 +16,6 @@ import {
   TaskSchema,
   CircleSchema,
 } from "../../api/schema";
-import { settings } from "../../settings";
 
 export interface SchemaTypes {
   member: Model<Member>;

--- a/src/util/manager/firestore.ts
+++ b/src/util/manager/firestore.ts
@@ -1,8 +1,6 @@
-import fs from "fs";
-import path from "path";
 import Bot from "../../api/bot";
 import { settings } from "../../settings";
-import { Firestore, Settings } from "@google-cloud/firestore";
+import { Firestore } from "@google-cloud/firestore";
 import Manager from "../../api/manager";
 
 export default class FirestoreManager extends Manager {

--- a/src/util/manager/points.ts
+++ b/src/util/manager/points.ts
@@ -65,7 +65,7 @@ export default class PointsManager extends Manager {
       return;
 
     if (!member.roles.cache.has(this.staffRoleId)) {
-      reaction.users.remove(user.id);
+      await reaction.users.remove(user.id);
       return this.bot.response.emit(
         msg.channel,
         `${user}, you are not authorized to approve points...`,
@@ -75,7 +75,7 @@ export default class PointsManager extends Manager {
     const encodedData = JSON.parse(
       decodeURIComponent(msg.embeds[0].description.match(re)![1])
     );
-    this.awardPoints(
+    await this.awardPoints(
       encodedData.points,
       encodedData.activity,
       new Set<string>([encodedData.snowflake])
@@ -197,7 +197,7 @@ export default class PointsManager extends Manager {
       true
     );
     if (!member) {
-      notifChannel.send(
+      await notifChannel.send(
         `Err: Couldn't find user ${data.tag} (${data.full_name})...`
       );
       return;
@@ -234,7 +234,7 @@ export default class PointsManager extends Manager {
             }),
           ],
         })
-        .catch((e: any) =>
+        .catch(() =>
           notifChannel.send(`DMs are off for ${data.tag} (${data.full_name})`)
         );
     return data.snowflake;
@@ -362,12 +362,12 @@ export default class PointsManager extends Manager {
         this.publicChannelId
       )) as TextChannel;
       if (success.length > 60)
-        logChannel.send({
+        await logChannel.send({
           content: `Awarded ${points} to ${success.length} users for ${activity}...`,
           allowedMentions: { parse: [] },
         });
       else if (success.length !== 0)
-        logChannel.send({
+        await logChannel.send({
           content: `Awarded ${points} points to ${success.join(
             ", "
           )} for ${activity}...`,
@@ -478,10 +478,10 @@ export default class PointsManager extends Manager {
         for (const [mentee, mentor] of Object.entries(pairs!)) {
           let mentorData = res.find((data) => data.users[0] === mentor)!;
           const activities = individualData.get(mentee)!.activities;
-          mentorData.points == activities &&
-          activities["Mentor/ Mentee Meeting"]
-            ? activities["Mentor/ Mentee Meeting"]
-            : 0;
+          mentorData.points +=
+            activities && activities["Mentor/ Mentee Meeting"]
+              ? activities["Mentor/ Mentee Meeting"]
+              : 0;
         }
         break;
       case "both":

--- a/src/util/manager/resolve.ts
+++ b/src/util/manager/resolve.ts
@@ -25,7 +25,7 @@ export default class ResolveManager extends Manager {
       (strategies.size === 0 || strategies.has("id")) &&
       /^[\d]{17,18}$/.test(toResolve)
     )
-      member = await guild?.members.fetch(toResolve);
+      member = await guild.members.fetch(toResolve);
 
     // Resolve on mention
     if (
@@ -33,7 +33,7 @@ export default class ResolveManager extends Manager {
       (strategies.size === 0 || strategies.has("mention")) &&
       /^<@!?[\d]{17,18}>$/.test(toResolve)
     )
-      member = await guild?.members.fetch(toResolve.slice(3, -1));
+      member = await guild.members.fetch(toResolve.slice(3, -1));
 
     if (
       !member &&
@@ -42,33 +42,35 @@ export default class ResolveManager extends Manager {
         strategies.has("username") ||
         strategies.has("nickname"))
     )
-      member = (await guild?.members.search({ query: toResolve })).values()[0];
+      member = (await guild.members.search({ query: toResolve })).values()[0];
 
     if (lenient) {
-      toResolve = this.makeLenient(toResolve);
+      toResolve = ResolveManager.makeLenient(toResolve);
       if (
         !member &&
         (strategies.size === 0 || strategies.has("tag")) &&
         /#\d{4}$/.test(toResolve)
       )
-        member = guild?.members.cache.find(
-          (gm) => this.makeLenient(gm.user.tag) === toResolve
+        member = guild.members.cache.find(
+          (gm) => ResolveManager.makeLenient(gm.user.tag) === toResolve
         );
 
       if (!member && (strategies.size === 0 || strategies.has("username")))
-        member = guild?.members.cache.find(
-          (gm) => this.makeLenient(gm.user.username) === toResolve
+        member = guild.members.cache.find(
+          (gm) => ResolveManager.makeLenient(gm.user.username) === toResolve
         );
 
       if (!member && (strategies.size === 0 || strategies.has("nickname")))
-        member = guild?.members.cache.find(
-          (gm) => this.makeLenient(gm.nickname ? gm.nickname : "") === toResolve
+        member = guild.members.cache.find(
+          (gm) =>
+            ResolveManager.makeLenient(gm.nickname ? gm.nickname : "") ===
+            toResolve
         );
     }
     return member;
   }
 
-  private makeLenient(str: string) {
+  private static makeLenient(str: string) {
     return str.replace(" ", "").toLowerCase();
   }
 }

--- a/src/util/manager/schedule.ts
+++ b/src/util/manager/schedule.ts
@@ -59,8 +59,7 @@ export default class ScheduleManager extends Manager {
         type: t.type,
         payload: t.payload,
       });
-    const job = schedule.scheduleJob(t.cron, () => this.runTask(t));
-    t.job = job;
+    t.job = schedule.scheduleJob(t.cron, () => this.runTask(t));
     this.tasks.set(t.id!, t);
     return t;
   }

--- a/src/util/manager/verification.ts
+++ b/src/util/manager/verification.ts
@@ -16,14 +16,14 @@ export default class VerificationManager extends Manager {
 
   public init() {}
 
-  public handle(msg: Message) {
+  public async handle(msg: Message) {
     if (msg.guild) {
       if (msg.channel.id == this.verificationChannelID && msg.member) {
         try {
           // Modify member nickname and roles
-          msg.member.setNickname(msg.content);
-          msg.member.roles.add(this.memberRoleID);
-          msg.delete();
+          await msg.member.setNickname(msg.content);
+          await msg.member.roles.add(this.memberRoleID);
+          await msg.delete();
 
           // Add to firebase
           let map: any = {};

--- a/src/util/response.ts
+++ b/src/util/response.ts
@@ -43,11 +43,11 @@ export default class ResponseUtil {
     this.format = format;
   }
 
-  private simple(msg: string, emoji: string): string {
+  private static simple(msg: string, emoji: string): string {
     return `${emoji} | ${msg}`;
   }
 
-  private embed(
+  private static embed(
     msg: string,
     emojiSet: { simple: string; embed: string; color: ColorResolvable }
   ): MessageEmbed {
@@ -63,7 +63,6 @@ export default class ResponseUtil {
   ): string | MessageEmbed {
     type = type || "normal";
     format = format || this.format;
-    let response: MessageEmbed | string = "";
     let em: { simple: string; embed: string; color: ColorResolvable };
     switch (type) {
       case "error":
@@ -85,8 +84,8 @@ export default class ResponseUtil {
         return "";
     }
     return format == "simple"
-      ? this.simple(message, em.simple)
-      : this.embed(message, em);
+      ? ResponseUtil.simple(message, em.simple)
+      : ResponseUtil.embed(message, em);
   }
 
   public emit(


### PR DESCRIPTION
I've noticed a lot of unhandled async errors causing the bot to crash during testing. Hopefully this fixes those issues, and everything gets caught.  

Remove [chained throw](https://github.com/acmutd/acm-bot/pull/39/commits/6659a7d6095b4ca172af4ac70b221f134de4bc2c#diff-a622efa98e0f9f2df47d1989d60a9a32aea336268f3572fb6313474a97bfbc19L130) when command errors occur. This is needed because the error manager has been removed.

Also fixes a ton of style things, access modifiers, etc.
- For this one, I ran the IntelliJ inspector and accepted some suggested changes I thought were useful

Another fix is changing == to += in PointsManager. This was messed up during the bot rewrite.
