### PR TITLE
Recache members before resolve

### DIFF
--- a/src/command/circle.ts
+++ b/src/command/circle.ts
@@ -15,7 +15,7 @@ export default class CircleCommand extends Command {
   constructor() {
     super({
       name: "circle",
-      description: "A suite of command that manage ACM Community Circles...",
+      description: "A suite of command that manage ACM Community Circles.",
       dmWorks: false,
       userPermissions: BigInt(268443664),
     });
@@ -31,7 +31,7 @@ export default class CircleCommand extends Command {
         break;
       default:
         msg.channel.send(
-          `User '${settings.prefix}circle help' to show a list of commands...`
+          `Use '${settings.prefix}circle help' to show a list of commands.`
         );
         break;
     }
@@ -126,7 +126,7 @@ async function addCircle(bot: Bot, msg: Message, args: string[]) {
   if (!added) {
     bot.response.emit(
       msg.channel,
-      `Could not add circle to the database...`,
+      `Could not add circle to the database.`,
       "error"
     );
     await circleRole.delete();
@@ -136,7 +136,7 @@ async function addCircle(bot: Bot, msg: Message, args: string[]) {
 
   bot.response.emit(
     msg.channel,
-    `Successfully created circle <@&${circleRole.id}>...`,
+    `Successfully created circle <@&${circleRole.id}>.`,
     "success"
   );
 }

--- a/src/command/ping.ts
+++ b/src/command/ping.ts
@@ -17,7 +17,7 @@ export default class PingCommand extends Command {
       msg.channel,
       `:ping_pong: | ${
         (new Date().getTime() - startTime) / 1000
-      }s response time...`,
+      }s response time.`,
       "success"
     );
   }

--- a/src/command/remind.ts
+++ b/src/command/remind.ts
@@ -4,7 +4,7 @@ export default class RemindCommand extends Command {
   constructor() {
     super({
       name: "remind",
-      description: "Setup a timed reminder...",
+      description: "Setup a timed reminder.",
       usage: ["remind [minutes] [message]"],
     });
   }
@@ -18,7 +18,7 @@ export default class RemindCommand extends Command {
     if (isNaN(minutes) || minutes < 1 || minutes > maxTime)
       return bot.response.emit(
         msg.channel,
-        `Invalid time in range [1-${maxTime}]...`,
+        `Invalid time in range [1-${maxTime}].`,
         "invalid"
       );
 
@@ -47,7 +47,7 @@ export default class RemindCommand extends Command {
     });
     return bot.response.emit(
       msg.channel,
-      `${msg.author}, I'll DM you with your reminder at '${dateStr}'...`,
+      `${msg.author}, I'll DM you with your reminder at '${dateStr}'.`,
       "success"
     );
   }

--- a/src/command/shoutout.ts
+++ b/src/command/shoutout.ts
@@ -6,14 +6,14 @@ export default class ShoutoutCommand extends Command {
   constructor() {
     super({
       name: "shoutout",
-      description: "Give a shoutout to someone special...",
+      description: "Give a shoutout to someone special.",
       usage: ["shoutout [list of mentions] [reason for shoutout]"],
     });
   }
 
   public async exec({ msg, bot, args }: CommandContext) {
     if (!/^<@!?[\d]{17,18}>/.test(args[0]))
-      return bot.response.emit(msg.channel, "No user mentions...", "invalid");
+      return bot.response.emit(msg.channel, "No user mentions.", "invalid");
 
     const receivers = [...msg.mentions.members!.values()];
     let title = `📣 ${

--- a/src/command/vcevent.ts
+++ b/src/command/vcevent.ts
@@ -11,7 +11,7 @@ export default class VCEventCommand extends Command {
   constructor() {
     super({
       name: "vcevent",
-      description: "Records user statistics for your current voice channel...",
+      description: "Records user statistics for your current voice channel.",
       usage: [
         "vcevent <start|stop|stats|list>",
         "vcevent <start|stop|stats> [channel-id]",
@@ -35,14 +35,14 @@ export default class VCEventCommand extends Command {
       )
         return bot.response.emit(
           msg.channel,
-          "Could not resolve that ID into a voice channel...",
+          "Could not resolve that ID into a voice channel.",
           "invalid"
         );
       vc = chan;
     } else {
       vc = msg.member?.voice.channel;
       if (!vc && action !== "list")
-        return bot.response.emit(msg.channel, "Please join a voice channel...");
+        return bot.response.emit(msg.channel, "Please join a voice channel.");
     }
     let data;
     switch (action) {
@@ -51,13 +51,13 @@ export default class VCEventCommand extends Command {
         if (bot.managers.activity.startVoiceEvent(vc))
           return bot.response.emit(
             msg.channel,
-            `VC Event started for ${vc}...`,
+            `VC Event started for ${vc}.`,
             "success"
           );
         else
           return bot.response.emit(
             msg.channel,
-            `VC Event already running ${vc}...`,
+            `VC Event already running ${vc}.`,
             "error"
           );
       case "stop":
@@ -66,7 +66,7 @@ export default class VCEventCommand extends Command {
         if (!data)
           return bot.response.emit(
             msg.channel,
-            `No running VC Event in ${vc}...`,
+            `No running VC Event in ${vc}.`,
             "error"
           );
         await this.printStats(msg.channel, vc, data);
@@ -76,7 +76,7 @@ export default class VCEventCommand extends Command {
         if (!data)
           return bot.response.emit(
             msg.channel,
-            `No running VC Event in ${vc}...`,
+            `No running VC Event in ${vc}.`,
             "error"
           );
         await this.printStats(msg.channel, vc, data);
@@ -117,7 +117,7 @@ export default class VCEventCommand extends Command {
     await channel.send({
       embeds: [
         new MessageEmbed({
-          title: `Time spent in ${voiceChannel}...`,
+          title: `Time spent in #${voiceChannel.name}`,
           description: descriptionArr.join("\n"),
         }),
       ],

--- a/src/command/vcping.ts
+++ b/src/command/vcping.ts
@@ -5,7 +5,7 @@ export default class VCPingCommand extends Command {
   constructor() {
     super({
       name: "vcping",
-      description: "Ping everyone in a voice channel...",
+      description: "Ping everyone in a voice channel.",
       usage: ["vcping", "vcping [channel-id]"],
       dmWorks: false,
     });
@@ -26,7 +26,7 @@ export default class VCPingCommand extends Command {
       )
         return bot.response.emit(
           msg.channel,
-          "Could not resolve the given ID into a valid voice channel...",
+          "Could not resolve the given ID into a valid voice channel.",
           "invalid"
         );
       voiceChannel = channel;
@@ -35,7 +35,7 @@ export default class VCPingCommand extends Command {
       if (!voiceChannel)
         return bot.response.emit(
           msg.channel,
-          "Please join a voice channel...",
+          "Please join a voice channel.",
           "invalid"
         );
     }

--- a/src/command/vcsnapshot.ts
+++ b/src/command/vcsnapshot.ts
@@ -6,9 +6,9 @@ export default class VCSnapshotCommand extends Command {
     super({
       name: "vcsnapshot",
       description:
-        "Take a snapshot of all users in your current voice channel...",
+        "Take a snapshot of all users in your current voice channel.",
       longDescription:
-        "Take a snapshot of all users in your current voice channel. You can also pass in a voice channel ID to take a snapshot of it without having to join...",
+        "Take a snapshot of all users in your current voice channel. You can also pass in a voice channel ID to take a snapshot of it without having to join.",
       usage: ["vcsnapshot", "vcsnapshot [channel-id]"],
       dmWorks: false,
     });
@@ -28,7 +28,7 @@ export default class VCSnapshotCommand extends Command {
       )
         return bot.response.emit(
           msg.channel,
-          `Could not resolve the given ID into a valid voice channel...`,
+          `Could not resolve the given ID into a valid voice channel.`,
           "invalid"
         );
       voiceChannel = chan;
@@ -37,7 +37,7 @@ export default class VCSnapshotCommand extends Command {
       if (!voiceChannel)
         return bot.response.emit(
           msg.channel,
-          `Please join a voice channel...`,
+          `Please join a voice channel.`,
           "invalid"
         );
     }

--- a/src/util/manager/command.ts
+++ b/src/util/manager/command.ts
@@ -97,7 +97,7 @@ export default class CommandManager extends Manager {
     if (this.bot.managers.indicator.hasUser("usingCommand", msg.author))
       return this.bot.response.emit(
         msg.channel,
-        "You are already using a command. Please complete that action before beginning another...",
+        "You are already using a command. Please complete that action before beginning another.",
         "invalid"
       );
 
@@ -127,7 +127,7 @@ export default class CommandManager extends Manager {
       await cmd.exec({ bot: this.bot, msg, args });
     } catch (e) {
       await msg.reply(
-        "Command execution failed. Please contact a bot maintainer..."
+        "Command execution failed. Please contact a bot maintainer."
       );
       console.error(e);
       // Don't throw and let the bot handle this as an unhandled rejection. Instead,

--- a/src/util/manager/database.ts
+++ b/src/util/manager/database.ts
@@ -66,7 +66,7 @@ export default class DatabaseManager extends Manager {
     };
     setup().then(() => {
       this.bot.logger.info(
-        "Cached circle, response, and reaction role data..."
+        "Cached circle, response, and reaction role data."
       );
     });
   }
@@ -77,13 +77,13 @@ export default class DatabaseManager extends Manager {
       useFindAndModify: false,
     });
     this.m.connection.on("error", (err) => {
-      this.bot.logger.error("Database connection error...");
+      this.bot.logger.error("Database connection error.");
       this.bot.logger.error(err);
     });
   }
   public dispose() {
     this.m.connection.close();
-    this.bot.logger.database("Closed database connection...");
+    this.bot.logger.database("Closed database connection.");
   }
   private async recache(schema: keyof SchemaTypes, cache?: keyof CacheTypes) {
     try {

--- a/src/util/manager/event.ts
+++ b/src/util/manager/event.ts
@@ -14,7 +14,7 @@ export default class EventManager extends Manager {
 
   public init(): void {
     fs.readdir(this.path, (err, files) => {
-      this.bot.logger.info(`Found ${files.length} event(s)...`);
+      this.bot.logger.info(`Found ${files.length} event(s).`);
       files.forEach((file) => {
         // Skip non-js files, such as map files.
         if (!file.endsWith(".js")) return;

--- a/src/util/manager/points.ts
+++ b/src/util/manager/points.ts
@@ -70,7 +70,7 @@ export default class PointsManager extends Manager {
       await reaction.users.remove(user.id);
       return this.bot.response.emit(
         msg.channel,
-        `${user}, you are not authorized to approve points...`,
+        `${user}, you are not authorized to approve points.`,
         "invalid"
       );
     }
@@ -126,7 +126,7 @@ export default class PointsManager extends Manager {
         userData.netId
       }\`\n**Activity**: \`${answers[2].choice.label}\`\n\n**Proof**:`,
       footer: {
-        text: `${points} points will be awarded upon approval...`,
+        text: `${points} points will be awarded upon approval.`,
       },
     });
     if (answers[4].type === "text")
@@ -179,7 +179,7 @@ export default class PointsManager extends Manager {
     } else {
       this.bot.response.emit(
         notifChannel,
-        `Registration failed. Please ensure that both members are in thi server and resubmit...`,
+        `Registration failed. Please ensure that both members are in this server and resubmit.`,
         "invalid"
       );
     }
@@ -200,7 +200,7 @@ export default class PointsManager extends Manager {
     );
     if (!member) {
       await notifChannel.send(
-        `Err: Couldn't find user ${data.tag} (${data.full_name})...`
+        `Err: Couldn't find user ${data.tag} (${data.full_name}).`
       );
       return;
     }
@@ -231,7 +231,7 @@ export default class PointsManager extends Manager {
               title: "Mentor/Mentee Registration Confirmation",
               description: `Hello **${data.full_name}**, thank you for registering!\n`,
               footer: {
-                text: "If you did not recently request this action, please conteact an ACM staff member...",
+                text: "If you did not recently request this action, please contact an ACM staff member.",
               },
             }),
           ],
@@ -365,19 +365,19 @@ export default class PointsManager extends Manager {
       )) as TextChannel;
       if (success.length > 60)
         await logChannel.send({
-          content: `Awarded ${points} to ${success.length} users for ${activity}...`,
+          content: `Awarded ${points} to ${success.length} users for ${activity}.`,
           allowedMentions: { parse: [] },
         });
       else if (success.length !== 0)
         await logChannel.send({
           content: `Awarded ${points} points to ${success.join(
             ", "
-          )} for ${activity}...`,
+          )} for ${activity}.`,
           allowedMentions: { users: [] },
         });
     }
     console.log(
-      `Awarded ${points} to ${success.length}/${awardees.size} users for ${activity}...`
+      `Awarded ${points} to ${success.length}/${awardees.size} users for ${activity}.`
     );
     return { success, failure };
   }

--- a/src/util/manager/resolve.ts
+++ b/src/util/manager/resolve.ts
@@ -17,6 +17,9 @@ export default class ResolveManager extends Manager {
   ): Promise<GuildMember | undefined> {
     let member: GuildMember | undefined;
 
+    // Ensure all members are in cache
+    await guild.members.fetch();
+
     // First perform strict searching]
 
     // Resolve on ID

--- a/src/util/manager/schedule.ts
+++ b/src/util/manager/schedule.ts
@@ -41,7 +41,7 @@ export default class ScheduleManager extends Manager {
       return res;
     };
     setup().then((res) => {
-      this.bot.logger.info(`Loaded ${res.length} scheduled tasks...`);
+      this.bot.logger.info(`Loaded ${res.length} scheduled tasks.`);
     });
   }
   public async createTask(task: Task): Promise<Task> {

--- a/src/util/wizard.ts
+++ b/src/util/wizard.ts
@@ -51,11 +51,11 @@ export default class Wizard {
         doneLoop: "done",
       },
       responses: {
-        quit: "Quitting wizard...",
+        quit: "Quitting wizard.",
         skip: "",
-        doneLoop: "Loop ended...",
-        time: "⏰ You ran out of time (+<time> seconds). Ending wizard...",
-        error: "Unexpected issue with the setup wizard, aborting...",
+        doneLoop: "Loop ended.",
+        time: "⏰ You ran out of time (+<time> seconds). Ending wizard.",
+        error: "Unexpected issue with the setup wizard, aborting.",
       },
     };
   }
@@ -173,7 +173,7 @@ export abstract class WizardNode {
               this.wizard.configs.commands.doneLoop +
               "' when you're finished. "
             : ""
-        }Enter '${this.wizard.configs.commands.quit}' to end the wizard...`,
+        }Enter '${this.wizard.configs.commands.quit}' to end the wizard.`,
       };
     }
     try {


### PR DESCRIPTION
Upon restarting bot, looks like it stopped caching members as aggressively before. Quick patch to force a member recache.

Not time sensitive--basic fix is already deployed to prod.  

Majority of changes are text strings that I didn't like (...) and typos. 