### PR TITLE
Increase activity reminder message fetch

### DIFF
--- a/src/util/manager/circle.ts
+++ b/src/util/manager/circle.ts
@@ -215,8 +215,8 @@ export default class CircleManager extends Manager {
   }
 
   private async getLastUserMessageInChannel(channel: TextBasedChannel): Promise<Message | undefined> {
-    // Fetch up to 10 messages from the channel
-    const messages = await channel.messages.fetch({ limit: 10 });
+    // Fetch up to 100 messages from the channel
+    const messages = await channel.messages.fetch({ limit: 100 });
 
     // Loop from most recent to least recent
     for (const [snowflake, msg] of [...messages.entries()].sort((a, b) => a > b ? -1 : a < b ? 1 : 0)) {


### PR DESCRIPTION
Searches in 10x more messages for non-bot (user) messages.  
Was running into issues where too many people joined a new circle and all the messages of the last 10 were join messages.

I made these changes directly on GitHub and did 0 testing, but I'm thinking surely this cant go wrong :)