### PR TITLE
Autoverification of users

### DIFF
--- a/src/api/bot.ts
+++ b/src/api/bot.ts
@@ -73,6 +73,7 @@ export default class Bot extends Client {
       IntentsBitField.Flags.GuildMessageReactions,
       IntentsBitField.Flags.DirectMessages,
       IntentsBitField.Flags.DirectMessageReactions,
+      IntentsBitField.Flags.MessageContent,
     ];
 
     super({

--- a/src/api/bot.ts
+++ b/src/api/bot.ts
@@ -84,6 +84,7 @@ export default class Bot extends Client {
     this.response = new ResponseUtil(config.responseFormat);
     this.restConnection = new REST({ version: "10" }).setToken(config.token);
     this.managers = {
+      firestore: new FirestoreManager(this),
       command: new CommandManager(this, config.commandPath),
       interaction: new InteractionManager(
         this,
@@ -99,7 +100,6 @@ export default class Bot extends Client {
       scheduler: new ScheduleManager(this),
       circle: new CircleManager(this),
       rero: new ReactionRoleManager(this),
-      firestore: new FirestoreManager(this),
       resolve: new ResolveManager(this),
       express: new ExpressManager(this, config.endpointPath),
       points: new PointsManager(this),

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -38,8 +38,8 @@ export const rrMessageDataSchema = z.object({
 export type RRMessageData = z.infer<typeof rrMessageDataSchema>;
 
 export const taskDataSchema = z.object({
-  _id: z.string(),
-  type: z.string(),
+  id: z.string(),
+  type: z.enum(["reminder", "circle_activity_reminder", "circle_activity"]),
   cron: z.union([z.string(), z.date()]),
   payload: z.string().default(""),
 });

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -41,7 +41,7 @@ export const taskDataSchema = z.object({
   _id: z.string(),
   type: z.string(),
   cron: z.union([z.string(), z.date()]),
-  payload: z.string(),
+  payload: z.string().default(""),
 });
 export type Task = z.infer<typeof taskDataSchema>;
 

--- a/src/event/guildmemberadd.ts
+++ b/src/event/guildmemberadd.ts
@@ -9,58 +9,11 @@ export default class GuildMemberAddEvent extends Event {
   }
 
   public async emit(bot: Bot, member: GuildMember) {
-    // Check if the user is already verified
-    if (await bot.managers.verification.handleRepeatJoin(member)) {
-      const embed = new EmbedBuilder()
-        .setTitle(`**Welcome back to the ACM Discord Server!** 🎉`)
-        .setAuthor({
-          name: `The Association for Computing Machinery`,
-          iconURL: "https://www.acmutd.co/png/acm-light.png",
-          url: "https://acmutd.co/",
-        })
-        .setColor(0xec7621)
-        .setFooter({
-          text: `Powered by ACM`,
-          iconURL: bot.user!.avatarURL() ?? "",
-        })
-        .addFields([
-          { name: `You are already verified!`, value: `Welcome back!` },
-        ]);
+    const embed = await this.createEmbed(bot, member);
 
-      await member.send({ embeds: [embed] });
-    }
-    const embed = new EmbedBuilder({
-      title: `**Welcome to the ACM Discord Server!** 🎉`,
-      author: {
-        name: `The Association for Computing Machinery`,
-        icon_url: "https://www.acmutd.co/png/acm-light.png",
-        url: "https://acmutd.co/",
-      },
-      color: 0xec7621,
-      footer: {
-        text: `Powered by ACM`,
-        icon_url: bot.user!.avatarURL() ?? "",
-      },
-      fields: [
-        {
-          name: `Step 1: Verify! The links below will become active once you verify.`,
-          value: `<#${bot.settings.channels.verification}>`,
-        },
-        {
-          name: `Step 2: Get roles!`,
-          value: `<#${bot.settings.channels.roles}>`,
-        },
-        {
-          name: `Step 3: Join Circles (interest groups)!`,
-          value: `<#${bot.settings.circles.joinChannel}>`,
-        },
-      ],
-    });
     try {
       const channel = await member.createDM();
-      if (channel) {
-        await channel.send({ embeds: [embed] });
-      }
+      channel?.send({ embeds: [embed] });
     } catch (e) {
       bot.managers.error.handleErr(
         e as Error,
@@ -68,5 +21,49 @@ export default class GuildMemberAddEvent extends Event {
       );
       console.error(e);
     }
+  }
+
+  private async createEmbed(
+    bot: Bot,
+    member: GuildMember
+  ): Promise<EmbedBuilder> {
+    const isRepeatJoin = await bot.managers.verification.handleRepeatJoin(
+      member
+    );
+
+    return new EmbedBuilder()
+      .setTitle(
+        `**Welcome${
+          isRepeatJoin ? " back" : ""
+        } to the ACM Discord Server!** 🎉`
+      )
+      .setAuthor({
+        name: `The Association for Computing Machinery`,
+        iconURL: "https://www.acmutd.co/png/acm-light.png",
+        url: "https://acmutd.co/",
+      })
+      .setColor(0xec7621)
+      .setFooter({
+        text: `Powered by ACM`,
+        iconURL: bot.user?.avatarURL() ?? "",
+      })
+      .addFields(
+        isRepeatJoin
+          ? [{ name: `You are already verified!`, value: `Welcome back!` }]
+          : [
+              {
+                name: `Step 1: Verify! The links below will become active once you verify.`,
+                value: `<#${bot.settings.channels.verification}>`,
+              },
+              {
+                name: `Step 2: Get roles!`,
+                value: `<#${bot.settings.channels.roles}>`,
+              },
+              {
+                name: `Step 3: Join Circles (interest groups)!`,
+                value: `<#${bot.settings.circles.joinChannel}>`,
+              },
+            ]
+      );
   }
 }

--- a/src/event/guildmemberadd.ts
+++ b/src/event/guildmemberadd.ts
@@ -9,6 +9,26 @@ export default class GuildMemberAddEvent extends Event {
   }
 
   public async emit(bot: Bot, member: GuildMember) {
+    // Check if the user is already verified
+    if (await bot.managers.verification.handleRepeatJoin(member)) {
+      const embed = new EmbedBuilder()
+        .setTitle(`**Welcome back to the ACM Discord Server!** 🎉`)
+        .setAuthor({
+          name: `The Association for Computing Machinery`,
+          iconURL: "https://www.acmutd.co/png/acm-light.png",
+          url: "https://acmutd.co/",
+        })
+        .setColor(0xec7621)
+        .setFooter({
+          text: `Powered by ACM`,
+          iconURL: bot.user!.avatarURL() ?? "",
+        })
+        .addFields([
+          { name: `You are already verified!`, value: `Welcome back!` },
+        ]);
+
+      await member.send({ embeds: [embed] });
+    }
     const embed = new EmbedBuilder({
       title: `**Welcome to the ACM Discord Server!** 🎉`,
       author: {

--- a/src/event/guildmemberadd.ts
+++ b/src/event/guildmemberadd.ts
@@ -9,7 +9,7 @@ export default class GuildMemberAddEvent extends Event {
   }
 
   public async emit(bot: Bot, member: GuildMember) {
-    const embed = await this.createEmbed(bot, member);
+    const embed = await createEmbed(bot, member);
 
     try {
       const channel = await member.createDM();
@@ -22,48 +22,44 @@ export default class GuildMemberAddEvent extends Event {
       console.error(e);
     }
   }
-
-  private async createEmbed(
-    bot: Bot,
-    member: GuildMember
-  ): Promise<EmbedBuilder> {
-    const isRepeatJoin = await bot.managers.verification.handleRepeatJoin(
-      member
-    );
-
-    return new EmbedBuilder()
-      .setTitle(
-        `**Welcome${
-          isRepeatJoin ? " back" : ""
-        } to the ACM Discord Server!** 🎉`
-      )
-      .setAuthor({
-        name: `The Association for Computing Machinery`,
-        iconURL: "https://www.acmutd.co/png/acm-light.png",
-        url: "https://acmutd.co/",
-      })
-      .setColor(0xec7621)
-      .setFooter({
-        text: `Powered by ACM`,
-        iconURL: bot.user?.avatarURL() ?? "",
-      })
-      .addFields(
-        isRepeatJoin
-          ? [{ name: `You are already verified!`, value: `Welcome back!` }]
-          : [
-              {
-                name: `Step 1: Verify! The links below will become active once you verify.`,
-                value: `<#${bot.settings.channels.verification}>`,
-              },
-              {
-                name: `Step 2: Get roles!`,
-                value: `<#${bot.settings.channels.roles}>`,
-              },
-              {
-                name: `Step 3: Join Circles (interest groups)!`,
-                value: `<#${bot.settings.circles.joinChannel}>`,
-              },
-            ]
-      );
-  }
 }
+
+const createEmbed = async (
+  bot: Bot,
+  member: GuildMember
+): Promise<EmbedBuilder> => {
+  const isRepeatJoin = await bot.managers.verification.handleRepeatJoin(member);
+
+  return new EmbedBuilder()
+    .setTitle(
+      `**Welcome${isRepeatJoin ? " back" : ""} to the ACM Discord Server!** 🎉`
+    )
+    .setAuthor({
+      name: `The Association for Computing Machinery`,
+      iconURL: "https://www.acmutd.co/png/acm-light.png",
+      url: "https://acmutd.co/",
+    })
+    .setColor(0xec7621)
+    .setFooter({
+      text: `Powered by ACM`,
+      iconURL: bot.user?.avatarURL() ?? "",
+    })
+    .addFields(
+      isRepeatJoin
+        ? [{ name: `You are already verified!`, value: `Welcome back!` }]
+        : [
+            {
+              name: `Step 1: Verify! The links below will become active once you verify.`,
+              value: `<#${bot.settings.channels.verification}>`,
+            },
+            {
+              name: `Step 2: Get roles!`,
+              value: `<#${bot.settings.channels.roles}>`,
+            },
+            {
+              name: `Step 3: Join Circles (interest groups)!`,
+              value: `<#${bot.settings.circles.joinChannel}>`,
+            },
+          ]
+    );
+};

--- a/src/event/messagecreate.ts
+++ b/src/event/messagecreate.ts
@@ -8,7 +8,6 @@ export default class MessageCreateEvent extends Event {
   }
 
   public async emit(bot: Bot, msg: Message): Promise<void> {
-    console.log({ msg, loc: "messageCreate.ts" });
     await bot.managers.command.handle(msg);
     await bot.managers.verification.handle(msg);
   }

--- a/src/event/messagecreate.ts
+++ b/src/event/messagecreate.ts
@@ -8,6 +8,7 @@ export default class MessageCreateEvent extends Event {
   }
 
   public async emit(bot: Bot, msg: Message): Promise<void> {
+    console.log({ msg, loc: "messageCreate.ts" });
     await bot.managers.command.handle(msg);
     await bot.managers.verification.handle(msg);
   }

--- a/src/util/manager/firestore.ts
+++ b/src/util/manager/firestore.ts
@@ -338,6 +338,36 @@ export default class FirestoreManager extends Manager {
     }
   }
 
+  // Checks if the user is already verified
+  public async isVerified(memberId: string): Promise<boolean> {
+    const data = await this.firestore
+      .collection("discord")
+      .doc("snowflake_to_name")
+      .get();
+    if (data.exists) {
+      const obj = data.data();
+      if (obj) {
+        return !!obj[memberId];
+      }
+    }
+    return false;
+  }
+
+  // Gets the name of the user from the verification
+  public async getVerifiedName(memberId: string): Promise<string | undefined> {
+    const data = await this.firestore
+      .collection("discord")
+      .doc("snowflake_to_name")
+      .get();
+    if (data.exists) {
+      const obj = data.data();
+      if (obj) {
+        return obj[memberId];
+      }
+    }
+    return undefined;
+  }
+
   public async updateVCEvent(id: string, newData: Partial<VCEvent>) {
     try {
       await this.firestore

--- a/src/util/manager/firestore.ts
+++ b/src/util/manager/firestore.ts
@@ -241,7 +241,10 @@ export default class FirestoreManager extends Manager {
     const data = await this.firestore.collection("task").get();
     const result: Task[] = [];
     data.forEach((doc) => {
-      const task = taskDataSchema.parse(doc.data());
+      if (!doc.exists) return;
+      const docData = doc.data();
+      if (!docData) return;
+      const task = taskDataSchema.parse(docData);
       result.push(task);
     });
     return result;

--- a/src/util/manager/firestore.ts
+++ b/src/util/manager/firestore.ts
@@ -62,7 +62,6 @@ export default class FirestoreManager extends Manager {
     await this.recache("rrmessages", "rrmessages");
     await this.recache("circles", "circles");
     await this.recache("coper", "copers");
-    this.bot.managers.scheduler.init();
   }
 
   private async recache(schema: CacheKeys, cache?: keyof CacheTypes) {
@@ -261,17 +260,17 @@ export default class FirestoreManager extends Manager {
   }
 
   public async findTask(id: string): Promise<Task | undefined> {
-    const data = await this.firestore.collection("task").doc(id).get();
-    if (data.exists) {
-      const task = taskDataSchema.parse(data.data());
-      return task;
-    }
-    return undefined;
+    const data = await this.firestore.collection("task").get();
+    // Should only be one
+    const doc = data.docs.find((doc) => doc.data().id === id);
+    if (!doc) return;
+    const task = taskDataSchema.parse(doc.data());
+    return task;
   }
 
   public async createTask(taskData: Task): Promise<boolean> {
     try {
-      await this.firestore.collection("task").doc(taskData._id).set(taskData);
+      await this.firestore.collection("task").doc(taskData.id).set(taskData);
       await this.recache("task");
       return true;
     } catch (e: any) {
@@ -341,34 +340,24 @@ export default class FirestoreManager extends Manager {
     }
   }
 
-  // Checks if the user is already verified
-  public async isVerified(memberId: string): Promise<boolean> {
-    const data = await this.firestore
-      .collection("discord")
-      .doc("snowflake_to_name")
-      .get();
-    if (data.exists) {
-      const obj = data.data();
-      if (obj) {
-        return !!obj[memberId];
-      }
-    }
-    return false;
+  /**
+   * Checks if a user is verified
+   * @param memberId
+   * @returns The name of the user if they are verified, undefined otherwise
+   */
+  public async isVerified(memberId: string): Promise<string | undefined> {
+    return await this.getVerifiedName(memberId);
   }
 
-  // Gets the name of the user from the verification
-  public async getVerifiedName(memberId: string): Promise<string | undefined> {
+  // Maybe implement cache?
+  private async getVerifiedName(memberId: string): Promise<string | undefined> {
     const data = await this.firestore
       .collection("discord")
       .doc("snowflake_to_name")
       .get();
-    if (data.exists) {
-      const obj = data.data();
-      if (obj) {
-        return obj[memberId];
-      }
-    }
-    return undefined;
+
+    // If the data doesn't exist, return undefined
+    return (data?.exists && data?.data()?.[memberId]) ?? undefined;
   }
 
   public async updateVCEvent(id: string, newData: Partial<VCEvent>) {

--- a/src/util/manager/schedule.ts
+++ b/src/util/manager/schedule.ts
@@ -35,7 +35,7 @@ export default class ScheduleManager extends Manager {
     const setup = async () => {
       const res = await this.bot.managers.firestore.fetchTasks();
       res.forEach(async (data) => {
-        await this.createTask(data as Task);
+        await this.createTask(data);
       });
       const vcRes = await this.bot.managers.firestore.fetchVCTasks();
       vcRes.forEach(async (data) => {
@@ -68,8 +68,8 @@ export default class ScheduleManager extends Manager {
     // Add task to the database
     const search = await this.bot.managers.firestore.findTask(t.id);
     if (!search) {
-      const res = await this.bot.managers.firestore.createTask({
-        _id: t.id,
+      await this.bot.managers.firestore.createTask({
+        id: t.id,
         type: t.type,
         cron: t.cron,
         payload: t.payload,

--- a/src/util/manager/schedule.ts
+++ b/src/util/manager/schedule.ts
@@ -57,7 +57,7 @@ export default class ScheduleManager extends Manager {
    */
   public async createTask(task: Task): Promise<Task> {
     // create local task
-    const t = { ...task };
+    const t: Task = { ...task, payload: task.payload || "" };
 
     // If ID passed in and already exists, return existing task
     if (t.id && this.tasks.has(t.id)) return this.tasks.get(t.id)!;

--- a/src/util/manager/verification.ts
+++ b/src/util/manager/verification.ts
@@ -41,7 +41,6 @@ export default class VerificationManager extends Manager {
   public async handleRepeatJoin(member: GuildMember): Promise<boolean> {
     // Check if the user is already verified
     const name = await this.bot.managers.firestore.isVerified(member.id);
-    console.log({ name });
     if (!name) return false;
 
     // Modify member nickname and roles

--- a/src/util/manager/verification.ts
+++ b/src/util/manager/verification.ts
@@ -21,6 +21,7 @@ export default class VerificationManager extends Manager {
     if (!msg.guild) return;
     if (msg.channel.id !== this.verificationChannelID) return;
     if (!msg.member) return;
+    console.log(msg);
 
     // Modify member nickname and roles
     try {
@@ -45,12 +46,14 @@ export default class VerificationManager extends Manager {
 
     // Modify member nickname and roles
     try {
-      await Promise.allSettled([
+      const res = await Promise.allSettled([
         member.setNickname(name),
         member.roles.add(this.memberRoleID),
       ]);
+      console.log(res);
+      return true;
     } catch (err: any) {
-      this.bot.logger.error(err, "Error handling repeat join");
+      this.bot.managers.error.handleErr(err, "Error verifying user.");
     }
     return true;
   }

--- a/src/util/manager/verification.ts
+++ b/src/util/manager/verification.ts
@@ -1,4 +1,4 @@
-import { Message } from "discord.js";
+import { GuildMember, Message } from "discord.js";
 import Bot from "../../api/bot";
 import Manager from "../../api/manager";
 
@@ -35,5 +35,22 @@ export default class VerificationManager extends Manager {
     } catch (err: any) {
       this.bot.logger.error(err);
     }
+  }
+
+  // Return true if the user is already in the database
+  public async handleRepeatJoin(member: GuildMember): Promise<boolean> {
+    // Check if the user is already verified
+    const isVerified = await this.bot.managers.firestore.isVerified(member.id);
+    if (!isVerified) throw new Error("User is not verified");
+
+    // Modify member nickname and roles
+    const nick = await this.bot.managers.firestore.getVerifiedName(member.id);
+
+    if (!nick) throw new Error("User is not verified");
+
+    await member.setNickname(nick);
+    await member.roles.add(this.memberRoleID);
+
+    return true;
   }
 }

--- a/src/util/manager/verification.ts
+++ b/src/util/manager/verification.ts
@@ -21,7 +21,6 @@ export default class VerificationManager extends Manager {
     if (!msg.guild) return;
     if (msg.channel.id !== this.verificationChannelID) return;
     if (!msg.member) return;
-    console.log(msg);
 
     // Modify member nickname and roles
     try {
@@ -42,15 +41,13 @@ export default class VerificationManager extends Manager {
   public async handleRepeatJoin(member: GuildMember): Promise<boolean> {
     // Check if the user is already verified
     const name = await this.bot.managers.firestore.isVerified(member.id);
+    console.log({ name });
     if (!name) return false;
 
     // Modify member nickname and roles
     try {
-      const res = await Promise.allSettled([
-        member.setNickname(name),
-        member.roles.add(this.memberRoleID),
-      ]);
-      console.log(res);
+      await member.setNickname(name);
+      await member.roles.add(this.memberRoleID);
       return true;
     } catch (err: any) {
       this.bot.managers.error.handleErr(err, "Error verifying user.");


### PR DESCRIPTION
Closes #65 
Tested in testing server with an alternate user.
Whenever a user loads in for the first time, they are welcomed and have to go through the verification process. ACM bot also sends a welcome message.
On repeat joins, they are automatically given the member role and have their nickname changed. ACM bot also sends a welcome-back message
